### PR TITLE
update readme code sample w/ correct import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the extension to your editor
 ```javascript
 import { Node, Editor } from "@tiptap/core";
 import StarterKit from '@tiptap/starter-kit';
-import ColumnExtension from "@gocapsule/column-extension";
+import { ColumnExtension } from "@gocapsule/column-extension";
 // don't forget to add style to see the columns
 import "@gocapsule/column-extension/src/index.css";
 


### PR DESCRIPTION
Adds bracket notation rather than default import to correctly import the extension