### PR TITLE
set module-entry to actual filename

### DIFF
--- a/packages/column-extension/package.json
+++ b/packages/column-extension/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "main": "dist/bundle.cjs.js",
   "umd": "dist/bundle.umd.js",
-  "module": "dist/bundle.esm.js",
+  "module": "dist/bundle.es.js",
   "types": "dist/bundle.es.d.ts",
   "style": "src/index.css",
   "files": [


### PR DESCRIPTION
the generated filename is `bundle.es.js` and not `bundle.esm.js`