### PR TITLE
feat: add parseHTML to nodes

### DIFF
--- a/packages/column-extension/src/Column.ts
+++ b/packages/column-extension/src/Column.ts
@@ -7,8 +7,15 @@ export const Column = Node.create({
   isolating: true,
   selectable: false,
 
+  parseHTML() {
+    return [{ tag: `div[data-type="${this.name}"]` }];
+  },
+
   renderHTML({ HTMLAttributes }) {
-    const attrs = mergeAttributes(HTMLAttributes, { class: 'column' });
+    const attrs = mergeAttributes(HTMLAttributes, {
+      'data-type': this.name,
+      class: 'column',
+    });
     return ['div', attrs, 0];
   },
 });

--- a/packages/column-extension/src/ColumnBlock.ts
+++ b/packages/column-extension/src/ColumnBlock.ts
@@ -37,8 +37,15 @@ export const ColumnBlock = Node.create<ColumnBlockOptions>({
     };
   },
 
+  parseHTML() {
+    return [{ tag: `div[data-type="${this.name}"]` }];
+  },
+
   renderHTML({ HTMLAttributes }) {
-    const attrs = mergeAttributes(HTMLAttributes, { class: 'column-block' });
+    const attrs = mergeAttributes(HTMLAttributes, {
+      'data-type': this.name,
+      class: 'column-block',
+    });
     return ['div', attrs, 0];
   },
 


### PR DESCRIPTION
This pull request makes changes to the `Column` and `ColumnBlock` nodes.
___

Add `data-type` attribute to `Column` and `ColumnBlock` node during rendering (`renderHTML()`).

This will allow us to use `parseHTML()` to read the content from HTML, in case a user saves their data in HTML instead of JSON.